### PR TITLE
fix: add "/" in the front of every api path

### DIFF
--- a/api/sspanel/sspanel.go
+++ b/api/sspanel/sspanel.go
@@ -233,7 +233,7 @@ func (c *APIClient) ReportUserTraffic(userTraffic *[]api.UserTraffic) error {
 
 // GetNodeRule will pull the audit rule form sspanel
 func (c *APIClient) GetNodeRule() (*[]api.DetectRule, error) {
-	path := "mod_mu/func/detect_rules"
+	path := "/mod_mu/func/detect_rules"
 	res, err := c.client.R().
 		SetResult(&Response{}).
 		ForceContentType("application/json").

--- a/api/v2board/v2board.go
+++ b/api/v2board/v2board.go
@@ -94,9 +94,9 @@ func (c *APIClient) GetNodeInfo() (nodeInfo *api.NodeInfo, err error) {
 	var path string
 	switch c.NodeType {
 	case "V2ray":
-		path = "api/v1/server/Deepbwork/config"
+		path = "/api/v1/server/Deepbwork/config"
 	case "Trojan":
-		path = "api/v1/server/TrojanTidalab/config"
+		path = "/api/v1/server/TrojanTidalab/config"
 	case "Shadowsocks":
 		if nodeInfo, err = c.ParseSSNodeResponse(); err == nil {
 			return nodeInfo, nil
@@ -139,11 +139,11 @@ func (c *APIClient) GetUserList() (UserList *[]api.UserInfo, err error) {
 	var path string
 	switch c.NodeType {
 	case "V2ray":
-		path = "api/v1/server/Deepbwork/user"
+		path = "/api/v1/server/Deepbwork/user"
 	case "Trojan":
-		path = "api/v1/server/TrojanTidalab/user"
+		path = "/api/v1/server/TrojanTidalab/user"
 	case "Shadowsocks":
-		path = "api/v1/server/ShadowsocksTidalab/user"
+		path = "/api/v1/server/ShadowsocksTidalab/user"
 	default:
 		return nil, fmt.Errorf("Unsupported Node type: %s", c.NodeType)
 	}
@@ -185,11 +185,11 @@ func (c *APIClient) ReportUserTraffic(userTraffic *[]api.UserTraffic) error {
 	var path string
 	switch c.NodeType {
 	case "V2ray":
-		path = "api/v1/server/Deepbwork/submit"
+		path = "/api/v1/server/Deepbwork/submit"
 	case "Trojan":
-		path = "api/v1/server/TrojanTidalab/submit"
+		path = "/api/v1/server/TrojanTidalab/submit"
 	case "Shadowsocks":
-		path = "api/v1/server/ShadowsocksTidalab/submit"
+		path = "/api/v1/server/ShadowsocksTidalab/submit"
 	}
 
 	data := make([]UserTraffic, len(*userTraffic))
@@ -220,7 +220,7 @@ func (c *APIClient) GetNodeRule() (*[]api.DetectRule, error) {
 	}
 
 	// V2board only support the rule for v2ray
-	path := "api/v1/server/Deepbwork/config"
+	path := "/api/v1/server/Deepbwork/config"
 	res, err := c.client.R().
 		ForceContentType("application/json").
 		Get(path)


### PR DESCRIPTION
在日志输出时，有些path前未加 "/" 会让人产生误解，由于并不是所有 path 前都没有加 “/"， 于是处理方式是把所有 path 前都加上了 “/"，并未修改 `assembleURL`  函数