### PR TITLE
address_base64_tag

### DIFF
--- a/service/controller/controller.go
+++ b/service/controller/controller.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"encoding/base64"
 	"fmt"
 	"log"
 	"reflect"
@@ -56,7 +57,7 @@ func (c *Controller) Start() error {
 		return err
 	}
 	c.nodeInfo = newNodeInfo
-	c.Tag = fmt.Sprintf("%s_%d", c.nodeInfo.NodeType, c.nodeInfo.Port)
+	c.Tag = fmt.Sprintf("%s_%s_%d", c.nodeInfo.NodeType, base64.StdEncoding.EncodeToString([]byte(c.config.ListenIP)), c.nodeInfo.Port)
 	err = c.addNewUser(userInfo, newNodeInfo)
 	if err != nil {
 		return err
@@ -150,7 +151,7 @@ func (c *Controller) nodeInfoMonitor() (err error) {
 		}
 		nodeInfoChanged = true
 		c.nodeInfo = newNodeInfo
-		c.Tag = fmt.Sprintf("%s_%d", newNodeInfo.NodeType, newNodeInfo.Port)
+		c.Tag = fmt.Sprintf("%s_%s_%d", newNodeInfo.NodeType, base64.StdEncoding.EncodeToString([]byte(c.config.ListenIP)), newNodeInfo.Port)
 		// Remove Old limiter
 		if err = c.DeleteInboundLimiter(oldtag); err != nil {
 			log.Print(err)

--- a/service/controller/inboundbuilder.go
+++ b/service/controller/inboundbuilder.go
@@ -2,6 +2,7 @@
 package controller
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -31,7 +32,7 @@ func InboundBuilder(config *Config, nodeInfo *api.NodeInfo) (*core.InboundHandle
 	}
 	inboundDetourConfig.PortList = portList
 	// Build Tag
-	inboundDetourConfig.Tag = fmt.Sprintf("%s_%d", nodeInfo.NodeType, nodeInfo.Port)
+	inboundDetourConfig.Tag = fmt.Sprintf("%s_%s_%d", nodeInfo.NodeType, base64.StdEncoding.EncodeToString([]byte(config.ListenIP)), nodeInfo.Port)
 	// SniffingConfig
 	sniffingConfig := &conf.SniffingConfig{
 		Enabled:      true,

--- a/service/controller/outboundbuilder.go
+++ b/service/controller/outboundbuilder.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -14,7 +15,7 @@ import (
 func OutboundBuilder(config *Config, nodeInfo *api.NodeInfo) (*core.OutboundHandlerConfig, error) {
 	outboundDetourConfig := &conf.OutboundDetourConfig{}
 	outboundDetourConfig.Protocol = "freedom"
-	outboundDetourConfig.Tag = fmt.Sprintf("%s_%d", nodeInfo.NodeType, nodeInfo.Port)
+	outboundDetourConfig.Tag = fmt.Sprintf("%s_%s_%d", nodeInfo.NodeType, base64.StdEncoding.EncodeToString([]byte(config.ListenIP)), nodeInfo.Port)
 
 	// Build Send IP address
 	if config.SendIP != "" {


### PR DESCRIPTION
鉴于多IP出口，监听不同的IP或者domain_socket时，因为下发的端口相同，产生的Tag一致导致运行失败，增加监听地址的base64数值加入tag标签。