### PR TITLE
resue resp and delay monitor

### DIFF
--- a/api/v2board/v2board.go
+++ b/api/v2board/v2board.go
@@ -27,6 +27,7 @@ type APIClient struct {
 	SpeedLimit    float64
 	DeviceLimit   int
 	LocalRuleList []api.DetectRule
+	ConfigResp    *simplejson.Json
 }
 
 // New create an api instance
@@ -157,6 +158,7 @@ func (c *APIClient) GetNodeInfo() (nodeInfo *api.NodeInfo, err error) {
 		Get(path)
 
 	response, err := c.parseResponse(res, path, err)
+	c.ConfigResp = response
 	if err != nil {
 		return nil, err
 	}
@@ -267,17 +269,8 @@ func (c *APIClient) GetNodeRule() (*[]api.DetectRule, error) {
 	}
 
 	// V2board only support the rule for v2ray
-	path := "/api/v1/server/Deepbwork/config"
-	res, err := c.client.R().
-		SetQueryParam("local_port", "1").
-		ForceContentType("application/json").
-		Get(path)
-
-	response, err := c.parseResponse(res, path, err)
-	if err != nil {
-		return nil, err
-	}
-	ruleListResponse := response.Get("routing").Get("rules").GetIndex(1).Get("domain").MustStringArray()
+	// fix: reuse config response
+	ruleListResponse := c.ConfigResp.Get("routing").Get("rules").GetIndex(1).Get("domain").MustStringArray()
 	for i, rule := range ruleListResponse {
 		ruleListItem := api.DetectRule{
 			ID:      i,
@@ -367,8 +360,8 @@ func (c *APIClient) ParseV2rayNodeResponse(nodeInfoResponse *simplejson.Json) (*
 		// Compatible with v2board 1.5.5-dev
 	} else if tmpInboundInfo, ok := nodeInfoResponse.CheckGet("inbounds"); ok {
 		tmpInboundInfo := tmpInboundInfo.MustArray()
-		marshal_byte, _ := json.Marshal(tmpInboundInfo[0].(map[string]interface{}))
-		inboundInfo, _ = simplejson.NewJson(marshal_byte)
+		marshalByte, _ := json.Marshal(tmpInboundInfo[0].(map[string]interface{}))
+		inboundInfo, _ = simplejson.NewJson(marshalByte)
 	} else {
 		return nil, fmt.Errorf("Unable to find inbound(s) in the nodeInfo.")
 	}
@@ -400,15 +393,9 @@ func (c *APIClient) ParseV2rayNodeResponse(nodeInfoResponse *simplejson.Json) (*
 		enableTLS = false
 	}
 
-	userInfo, err := c.GetUserList()
-	if err != nil {
-		return nil, err
-	}
-	if len(*userInfo) > 0 {
-		alterID = (*userInfo)[0].AlterID
-	}
 	// Create GeneralNodeInfo
-	nodeinfo := &api.NodeInfo{
+	// AlterID will be updated after next sync
+	nodeInfo := &api.NodeInfo{
 		NodeType:          c.NodeType,
 		NodeID:            c.NodeID,
 		Port:              port,
@@ -422,5 +409,5 @@ func (c *APIClient) ParseV2rayNodeResponse(nodeInfoResponse *simplejson.Json) (*
 		ServiceName:       serviceName,
 		Header:            header,
 	}
-	return nodeinfo, nil
+	return nodeInfo, nil
 }

--- a/service/controller/controller.go
+++ b/service/controller/controller.go
@@ -57,6 +57,10 @@ func (c *Controller) Start() error {
 	if err != nil {
 		return err
 	}
+	// initial node AlterID
+	if len(*userInfo) > 0 {
+		c.nodeInfo.AlterID = (*userInfo)[0].AlterID
+	}
 	err = c.addNewUser(userInfo, newNodeInfo)
 	if err != nil {
 		return err
@@ -86,9 +90,18 @@ func (c *Controller) Start() error {
 		Execute:  c.userInfoMonitor,
 	}
 	log.Printf("[%s: %d] Start monitor node status", c.nodeInfo.NodeType, c.nodeInfo.NodeID)
-	_ = c.nodeInfoMonitorPeriodic.Start()
+	// delay to start nodeInfoMonitor
+	go func() {
+		time.Sleep(time.Duration(c.config.UpdatePeriodic) * time.Second)
+		_ = c.nodeInfoMonitorPeriodic.Start()
+	}()
+
 	log.Printf("[%s: %d] Start report node status", c.nodeInfo.NodeType, c.nodeInfo.NodeID)
-	_ = c.userReportPeriodic.Start()
+	// delay to start userReport
+	go func() {
+		time.Sleep(time.Duration(c.config.UpdatePeriodic) * time.Second)
+		_ = c.userReportPeriodic.Start()
+	}()
 	return nil
 }
 

--- a/service/controller/controller.go
+++ b/service/controller/controller.go
@@ -138,6 +138,11 @@ func (c *Controller) nodeInfoMonitor() (err error) {
 		return nil
 	}
 
+	// Fetch node AlterID
+	if len(*newUserInfo) > 0 {
+		c.nodeInfo.AlterID = (*newUserInfo)[0].AlterID
+	}
+
 	var nodeInfoChanged = false
 	// If nodeInfo changed
 	if !reflect.DeepEqual(c.nodeInfo, newNodeInfo) {


### PR DESCRIPTION
Fix: Reuse response info for reduce server load.
Fix: Monitor service will delay UpdatePeriodic to start.

It seem that the alterID is not usefull for next version in v2ray. Can it delete now? 
Due to fetch userinfo after nodeinfo, the node alterID will update after fetch userinfo. 