### PR TITLE
修复变量逻辑问题

### DIFF
--- a/api/sspanel/sspanel.go
+++ b/api/sspanel/sspanel.go
@@ -785,11 +785,11 @@ func (c *APIClient) ParseSSPanelNodeInfo(nodeInfoResponse *NodeInfoResponse) (*a
 
 		// Select transport protocol
 		transportProtocol = nodeConfig.Network // try to read transport protocol from config
+		if nodeConfig.Network == "" {
+			transportProtocol = "tcp" // default
+		}
 		if nodeConfig.Grpc == "1" {
 			transportProtocol = "grpc"
-		}
-		if nodeConfig.Network != "" {
-			transportProtocol = "tcp" // default
 		}
 	}
 


### PR DESCRIPTION
用于明文WS 与GRPC=1 不能正常使用的情况