### PR TITLE
update: refactor the global limit

### DIFF
--- a/common/limiter/model.go
+++ b/common/limiter/model.go
@@ -1,7 +1,7 @@
 package limiter
 
 type GlobalDeviceLimitConfig struct {
-	Limit         int    `mapstructure:"Limit"`
+	Enable        bool   `mapstructure:"Enable"`
 	RedisAddr     string `mapstructure:"RedisAddr"` // host:port
 	RedisPassword string `mapstructure:"RedisPassword"`
 	RedisDB       int    `mapstructure:"RedisDB"`

--- a/main/config.yml.example
+++ b/main/config.yml.example
@@ -39,7 +39,7 @@ Nodes:
         LimitSpeed: 0 # The speedlimit of a limited user (unit: mbps)
         LimitDuration: 0 # How many minutes will the limiting last (unit: minute)
       GlobalDeviceLimitConfig:
-        Limit: 0 # The global device limit of a user, 0 means disable
+        Enable: false # Enable the global device limit of a user
         RedisAddr: 127.0.0.1:6379 # The redis server address
         RedisPassword: YOUR PASSWORD # Redis password
         RedisDB: 0 # Redis DB

--- a/service/controller/errors.generated.go
+++ b/service/controller/errors.generated.go
@@ -1,4 +1,4 @@
-package mydispatcher
+package controller
 
 import "github.com/xtls/xray-core/common/errors"
 


### PR DESCRIPTION
fix: some log prefix

It an enhance device limit. Redis just use to sync local ipMap. If global limit is enabled. The online report will faliure. All enabled nodes will report the device from redis.