### PR TITLE
修复http伪装配置解析

### DIFF
--- a/api/sspanel/sspanel.go
+++ b/api/sspanel/sspanel.go
@@ -459,7 +459,7 @@ func (c *APIClient) ParseV2rayNodeResponse(nodeInfoResponse *NodeInfoResponse) (
 			host = value
 		case "servicename":
 			serviceName = value
-		case "headertype":
+		case "headerType":
 			HeaderType = value
 		}
 	}


### PR DESCRIPTION
根据sspanel代码，headerType 才是下发订阅的参数
https://github.com/Anankke/SSPanel-Uim/blob/2022.6/src/Utils/AppURI.php#LL70C34-L70C34
https://xrayr-project.github.io/XrayR-doc/dui-jie-sspanel/sspanel/v2ray.html#tcp+http%E7%A4%BA%E4%BE%8B

