### PR TITLE
feat: update sspanel model

### DIFF
--- a/api/apimodel.go
+++ b/api/apimodel.go
@@ -57,19 +57,15 @@ type NodeInfo struct {
 }
 
 type UserInfo struct {
-	UID           int
-	Email         string
-	Passwd        string
-	Port          uint32
-	Method        string
-	SpeedLimit    uint64 // Bps
-	DeviceLimit   int
-	Protocol      string
-	ProtocolParam string
-	Obfs          string
-	ObfsParam     string
-	UUID          string
-	AlterID       uint16
+	UID         int
+	Email       string
+	UUID        string
+	Passwd      string
+	Port        uint32
+	AlterID     uint16
+	Method      string
+	SpeedLimit  uint64 // Bps
+	DeviceLimit int
 }
 
 type OnlineUser struct {

--- a/api/sspanel/model.go
+++ b/api/sspanel/model.go
@@ -8,7 +8,6 @@ type NodeInfoResponse struct {
 	Class           int             `json:"node_class"`
 	SpeedLimit      float64         `json:"node_speedlimit"`
 	TrafficRate     float64         `json:"traffic_rate"`
-	MuOnly          int             `json:"mu_only"`
 	Sort            int             `json:"sort"`
 	RawServerString string          `json:"server"`
 	Type            string          `json:"type"`
@@ -17,22 +16,17 @@ type NodeInfoResponse struct {
 }
 
 type CustomConfig struct {
-	OffsetPortUser string          `json:"offset_port_user"`
 	OffsetPortNode string          `json:"offset_port_node"`
-	ServerSub      string          `json:"server_sub"`
 	Host           string          `json:"host"`
 	Method         string          `json:"method"`
-	V2Port         string          `json:"v2_port"`
 	TLS            string          `json:"tls"`
 	EnableVless    string          `json:"enable_vless"`
-	AlterID        string          `json:"alter_id"`
 	Network        string          `json:"network"`
 	Security       string          `json:"security"`
 	Path           string          `json:"path"`
 	VerifyCert     bool            `json:"verify_cert"`
 	Obfs           string          `json:"obfs"`
 	Header         json.RawMessage `json:"header"`
-	TrojanPort     string          `json:"trojan_port"`
 	AllowInsecure  string          `json:"allow_insecure"`
 	Servicename    string          `json:"servicename"`
 	EnableXtls     string          `json:"enable_xtls"`
@@ -41,22 +35,14 @@ type CustomConfig struct {
 
 // UserResponse is the response of user
 type UserResponse struct {
-	ID            int     `json:"id"`
-	Email         string  `json:"email"`
-	Passwd        string  `json:"passwd"`
-	Port          uint32  `json:"port"`
-	Method        string  `json:"method"`
-	SpeedLimit    float64 `json:"node_speedlimit"`
-	DeviceLimit   int     `json:"node_connector"`
-	Protocol      string  `json:"protocol"`
-	ProtocolParam string  `json:"protocol_param"`
-	Obfs          string  `json:"obfs"`
-	ObfsParam     string  `json:"obfs_param"`
-	ForbiddenIP   string  `json:"forbidden_ip"`
-	ForbiddenPort string  `json:"forbidden_port"`
-	UUID          string  `json:"uuid"`
-	MultiUser     int     `json:"is_multi_user"`
-	AliveIP       int     `json:"alive_ip"`
+	ID          int     `json:"id"`
+	Passwd      string  `json:"passwd"`
+	Port        uint32  `json:"port"`
+	Method      string  `json:"method"`
+	SpeedLimit  float64 `json:"node_speedlimit"`
+	DeviceLimit int     `json:"node_iplimit"`
+	UUID        string  `json:"uuid"`
+	AliveIP     int     `json:"alive_ip"`
 }
 
 // Response is the common response
@@ -70,7 +56,7 @@ type PostData struct {
 	Data interface{} `json:"data"`
 }
 
-// SystemLoad is the data structure of systemload
+// SystemLoad is the data structure of system load
 type SystemLoad struct {
 	Uptime string `json:"uptime"`
 	Load   string `json:"load"`

--- a/api/sspanel/sspanel.go
+++ b/api/sspanel/sspanel.go
@@ -518,17 +518,6 @@ func (c *APIClient) ParseSSNodeResponse(nodeInfoResponse *NodeInfoResponse) (*ap
 	if err := json.Unmarshal(response.Data, userListResponse); err != nil {
 		return nil, fmt.Errorf("unmarshal %s failed: %s", reflect.TypeOf(userListResponse), err)
 	}
-	// Find the multi-user
-	for _, u := range *userListResponse {
-		if u.MultiUser > 0 {
-			port = u.Port
-			method = u.Method
-			break
-		}
-	}
-	if port == 0 || method == "" {
-		return nil, fmt.Errorf("cant find the single port multi user")
-	}
 
 	if c.SpeedLimit > 0 {
 		speedLimit = uint64((c.SpeedLimit * 1000000) / 8)
@@ -727,18 +716,13 @@ func (c *APIClient) ParseUserListResponse(userInfoResponse *[]UserResponse) (*[]
 			speedLimit = uint64((user.SpeedLimit * 1000000) / 8)
 		}
 		userList = append(userList, api.UserInfo{
-			UID:           user.ID,
-			Email:         user.Email,
-			UUID:          user.UUID,
-			Passwd:        user.Passwd,
-			SpeedLimit:    speedLimit,
-			DeviceLimit:   deviceLimit,
-			Port:          user.Port,
-			Method:        user.Method,
-			Protocol:      user.Protocol,
-			ProtocolParam: user.ProtocolParam,
-			Obfs:          user.Obfs,
-			ObfsParam:     user.ObfsParam,
+			UID:         user.ID,
+			UUID:        user.UUID,
+			Passwd:      user.Passwd,
+			SpeedLimit:  speedLimit,
+			DeviceLimit: deviceLimit,
+			Port:        user.Port,
+			Method:      user.Method,
 		})
 	}
 
@@ -786,12 +770,6 @@ func (c *APIClient) ParseSSPanelNodeInfo(nodeInfoResponse *NodeInfoResponse) (*a
 		transportProtocol = nodeConfig.Network
 		tlsType = nodeConfig.Security
 
-		if parsedAlterID, err := strconv.ParseInt(nodeConfig.AlterID, 10, 16); err != nil {
-			return nil, err
-		} else {
-			alterID = uint16(parsedAlterID)
-		}
-
 		if tlsType == "tls" || tlsType == "xtls" {
 			enableTLS = true
 		}
@@ -804,10 +782,7 @@ func (c *APIClient) ParseSSPanelNodeInfo(nodeInfoResponse *NodeInfoResponse) (*a
 		tlsType = "tls"
 		transportProtocol = "tcp"
 
-		// Select security type
-		if nodeConfig.EnableXtls == "1" {
-			tlsType = "xtls"
-		} else if nodeConfig.Security != "" {
+		if nodeConfig.Security != "" {
 			tlsType = nodeConfig.Security // try to read security from config
 		}
 


### PR DESCRIPTION
1. remove remaining SSR-related params.
2. `node_connector` has been replaced with `node_speedlimit`.
3. `mu_only` and `is_multi_user` are removed alongside SSR support, there is no way to use the origin shadowsocks node type with mu enabled, only the ss2022 type has mu support.
4. user email has been removed from WebAPI data since its refactor back in the 2021.9 release
5. OffsetPortUser, ServerSub, V2Port, TrojanPort, ForbiddenIP, and ForbiddenPort are never used and will soon be removed from WebAPI and custom config examples.
6. Vmess AlterID should always be 0 to enable the AEAD method.