### PR TITLE
support passing redis network and redis username to redis client

### DIFF
--- a/common/limiter/limiter.go
+++ b/common/limiter/limiter.go
@@ -66,7 +66,9 @@ func (l *Limiter) AddInboundLimiter(tag string, nodeSpeedLimit uint64, userList 
 		// init redis store
 		rs := redisStore.NewRedis(redis.NewClient(
 			&redis.Options{
+				Network:  globalLimit.RedisNetwork,
 				Addr:     globalLimit.RedisAddr,
+				Username: globalLimit.RedisUsername,
 				Password: globalLimit.RedisPassword,
 				DB:       globalLimit.RedisDB,
 			}),

--- a/common/limiter/model.go
+++ b/common/limiter/model.go
@@ -2,7 +2,9 @@ package limiter
 
 type GlobalDeviceLimitConfig struct {
 	Enable        bool   `mapstructure:"Enable"`
-	RedisAddr     string `mapstructure:"RedisAddr"` // host:port
+	RedisNetwork  string `mapstructure:"RedisNetwork"` // tcp or unix
+	RedisAddr     string `mapstructure:"RedisAddr"`    // host:port, or /path/to/unix.sock
+	RedisUsername string `mapstructure:"RedisUsername"`
 	RedisPassword string `mapstructure:"RedisPassword"`
 	RedisDB       int    `mapstructure:"RedisDB"`
 	Timeout       int    `mapstructure:"Timeout"`

--- a/release/config/config.yml.example
+++ b/release/config/config.yml.example
@@ -1,5 +1,5 @@
 Log:
-  Level: warning # Log level: none, error, warning, info, debug 
+  Level: warning # Log level: none, error, warning, info, debug
   AccessPath: # /etc/XrayR/access.Log
   ErrorPath: # /etc/XrayR/error.log
 DnsConfigPath: # /etc/XrayR/dns.json # Path to dns config, check https://xtls.github.io/config/dns.html for help
@@ -40,7 +40,9 @@ Nodes:
         LimitDuration: 0 # How many minutes will the limiting last (unit: minute)
       GlobalDeviceLimitConfig:
         Enable: false # Enable the global device limit of a user
-        RedisAddr: 127.0.0.1:6379 # The redis server address
+        RedisNetwork: tcp # Redis protocol, tcp or unix
+        RedisAddr: 127.0.0.1:6379 # Redis server address, or unix socket path
+        RedisUsername: # Redis username
         RedisPassword: YOUR PASSWORD # Redis password
         RedisDB: 0 # Redis DB
         Timeout: 5 # Timeout for redis request


### PR DESCRIPTION
`go-redis` will guess `Network` if it is empty. so there is no backward compatibility issue.

https://github.com/redis/go-redis/blob/v9.4.0/options.go#L156