### PR TITLE
fix custom inbound listener to not use 0.0.0.0

### DIFF
--- a/release/config/custom_inbound.json
+++ b/release/config/custom_inbound.json
@@ -1,6 +1,6 @@
 [
   {
-    "listen": "0.0.0.0",
+    "listen": "127.0.0.1",
     "port": 1234,
     "protocol": "socks",
     "settings": {


### PR DESCRIPTION
For safety reasons, it is not recommended to listen on 0.0.0.0 using a custom inbound sosocks protocol.