### PR TITLE
Update  actions/upload-artifact: v3 to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,7 +176,7 @@ jobs:
         run: |
           mv build_assets XrayR-$ASSET_NAME
       - name: Upload files to Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: XrayR-${{ steps.get_filename.outputs.ASSET_NAME }}
           path: |


### PR DESCRIPTION
Error: This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v3. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/